### PR TITLE
Add HS code, make test prices more resiliant

### DIFF
--- a/docs/content/en/orders.md
+++ b/docs/content/en/orders.md
@@ -190,6 +190,7 @@ const order = await client.orders.create({
     description: 'T-shirt',
     value: '20.00',
     country_of_origin: 'CN',
+    hs_code: '610910',
   },
 });
 ```
@@ -261,7 +262,8 @@ You can prevent duplicate orders by using an **Idempotency Key** header with thi
   "contents": {
     "description": "T-shirt",
     "value": "20.00",
-    "country_of_origin": "China"
+    "country_of_origin": "China",
+    "hs_code": "610910"
   }
 }
 ```
@@ -290,7 +292,7 @@ Viewing an order will give you all the details associated with an existing Sendl
 - `tracking_url` (`String`)
   - The order’s public tracking page. Tracking page updates as the parcel progresses from sender to receiver. The url can be shared and viewed without a Sendle Account and contains no personal information about either party.
 - `labels` (`Array<{ format: String; size: "a4" | "cropped"; url: string }>`)
-  - Covered in detail in the [label section](https://api-doc.sendle.com/#getting-labels). After the initial order booking, this field may contain the labels or may contain null. If it contains null it means the labels are still being generated. In which case, you will need to re-fetch the order with a GET request, or use the label endpoint described in the link above.
+  - Covered in detail in the [label section](https://developers.sendle.com/reference/getting-labels). After the initial order booking, this field may contain the labels or may contain null. If it contains null it means the labels are still being generated. In which case, you will need to re-fetch the order with a GET request, or use the label endpoint described in the link above.
 - `scheduling` (`{ is_cancellable: boolean; pickup_date: string; picked_up_on: string | null; delivered_on: string | null; estimated_delivery_date_minimum: string; estimated_delivery_date_maximum: string; }`)
   - Information regarding the order’s delivery status and whether an order can be cancelled. Some fields return null depending on the state of the order.
   - `pickup_date` is the date the courier has been requested to pick up the parcel. `picked_up_on` is the date the parcel was actually picked up.
@@ -503,4 +505,4 @@ const order = await client.orders.create({
 
 As a fallback, `sendle-node` generates an unique ID using [`nanoid`](https://github.com/ai/nanoid)
 
-To learn more about Indempotency keys, visit the [Sendle API Documentation](https://api-doc.sendle.com/#idempotency-keys)
+To learn more about Indempotency keys, visit the [Sendle API Documentation](https://developers.sendle.com/reference/idempotency-keys)

--- a/src/types.ts
+++ b/src/types.ts
@@ -505,6 +505,13 @@ export namespace Sendle {
        * Country names can vary between systems so it is recommended to use ISO country codes where possible.
        */
       country_of_origin: string;
+
+      /**
+       * A Harmonized System code for this item, appropriate for the destination country.
+       * Single HS tarrif code only.
+       * Must contain 6–10 digits with separating dots.
+       */
+      hs_code: string;
     };
   }
 

--- a/test/__snapshots__/orders.test.ts.snap
+++ b/test/__snapshots__/orders.test.ts.snap
@@ -190,11 +190,11 @@ exports[`Orders > should create an international order 1`] = `
   },
   "price_breakdown": {
     "base": {
-      "amount": 23.35,
+      "amount": Any<Number>,
       "currency": "AUD",
     },
     "base_tax": {
-      "amount": 0,
+      "amount": Any<Number>,
       "currency": "AUD",
     },
     "cover": {
@@ -214,11 +214,11 @@ exports[`Orders > should create an international order 1`] = `
       "currency": "AUD",
     },
     "fuel_surcharge": {
-      "amount": 1.63,
+      "amount": Any<Number>,
       "currency": "AUD",
     },
     "fuel_surcharge_tax": {
-      "amount": 0,
+      "amount": Any<Number>,
       "currency": "AUD",
     },
   },

--- a/test/__snapshots__/orders.test.ts.snap
+++ b/test/__snapshots__/orders.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Orders > should cancel an order 1`] = `
 {
-  "cancellation_message": "Cancelled by thomas_kambio_app during picking up",
+  "cancellation_message": Any<String>,
   "cancelled_at": Any<String>,
   "customer_reference": "1337",
   "metadata": {
@@ -32,25 +32,25 @@ exports[`Orders > should create a domestic order 1`] = `
   "packaging_type": "box",
   "price": {
     "gross": {
-      "amount": 25.87,
+      "amount": Any<Number>,
       "currency": "AUD",
     },
     "net": {
-      "amount": 23.52,
+      "amount": Any<Number>,
       "currency": "AUD",
     },
     "tax": {
-      "amount": 2.35,
+      "amount": Any<Number>,
       "currency": "AUD",
     },
   },
   "price_breakdown": {
     "base": {
-      "amount": 23.52,
+      "amount": Any<Number>,
       "currency": "AUD",
     },
     "base_tax": {
-      "amount": 2.35,
+      "amount": Any<Number>,
       "currency": "AUD",
     },
     "cover": {
@@ -70,11 +70,11 @@ exports[`Orders > should create a domestic order 1`] = `
       "currency": "AUD",
     },
     "fuel_surcharge": {
-      "amount": 0,
+      "amount": Any<Number>,
       "currency": "AUD",
     },
     "fuel_surcharge_tax": {
-      "amount": 0,
+      "amount": Any<Number>,
       "currency": "AUD",
     },
   },
@@ -106,6 +106,7 @@ exports[`Orders > should create a domestic order 1`] = `
     "is_cancellable": true,
     "picked_up_on": null,
     "pickup_date": Any<String>,
+    "status": null,
   },
   "sender": {
     "address": {
@@ -118,10 +119,10 @@ exports[`Orders > should create a domestic order 1`] = `
     },
     "contact": {
       "company": null,
-      "email": "thomas@kanvi.com.au",
+      "email": Any<String>,
       "name": "Lex Luthor",
       "phone": null,
-      "sendle_id": "thomas_kambio_app",
+      "sendle_id": Any<String>,
     },
     "instructions": null,
   },
@@ -129,7 +130,7 @@ exports[`Orders > should create a domestic order 1`] = `
   "state": "Pickup",
   "tax_breakdown": {
     "gst": {
-      "amount": 2.35,
+      "amount": Any<Number>,
       "currency": "AUD",
       "rate": 0.1,
     },
@@ -168,22 +169,22 @@ exports[`Orders > should create an international order 1`] = `
       "country_of_origin": "China",
       "currency": "AUD",
       "description": "T-shirt",
-      "hs_code": null,
+      "hs_code": "610910",
       "quantity": 1,
       "value": "20.0",
     },
   ],
   "price": {
     "gross": {
-      "amount": 23.35,
+      "amount": Any<Number>,
       "currency": "AUD",
     },
     "net": {
-      "amount": 23.35,
+      "amount": Any<Number>,
       "currency": "AUD",
     },
     "tax": {
-      "amount": 0,
+      "amount": Any<Number>,
       "currency": "AUD",
     },
   },
@@ -213,7 +214,7 @@ exports[`Orders > should create an international order 1`] = `
       "currency": "AUD",
     },
     "fuel_surcharge": {
-      "amount": 0,
+      "amount": 1.63,
       "currency": "AUD",
     },
     "fuel_surcharge_tax": {
@@ -249,6 +250,7 @@ exports[`Orders > should create an international order 1`] = `
     "is_cancellable": true,
     "picked_up_on": null,
     "pickup_date": Any<String>,
+    "status": null,
   },
   "sender": {
     "address": {
@@ -261,10 +263,10 @@ exports[`Orders > should create an international order 1`] = `
     },
     "contact": {
       "company": null,
-      "email": "thomas@kanvi.com.au",
+      "email": Any<String>,
       "name": "Lex Luthor",
       "phone": "0412 345 678",
-      "sendle_id": "thomas_kambio_app",
+      "sendle_id": Any<String>,
     },
     "instructions": "Knock loudly",
   },
@@ -296,6 +298,7 @@ exports[`Orders > should return tracking for my order 1`] = `
     "estimated_delivery_date_minimum": Any<String>,
     "picked_up_on": null,
     "pickup_date": Any<String>,
+    "status": null,
   },
   "state": "Pickup",
   "status": {

--- a/test/__snapshots__/products.test.ts.snap
+++ b/test/__snapshots__/products.test.ts.snap
@@ -11,11 +11,11 @@ exports[`Products > should get a list of products 1`] = `
   "plan": "Sendle Easy",
   "price_breakdown": {
     "base": {
-      "amount": 9.3,
+      "amount": Any<Number>,
       "currency": "AUD",
     },
     "base_tax": {
-      "amount": 0.93,
+      "amount": Any<Number>,
       "currency": "AUD",
     },
     "cover": {
@@ -35,11 +35,11 @@ exports[`Products > should get a list of products 1`] = `
       "currency": "AUD",
     },
     "fuel_surcharge": {
-      "amount": 0,
+      "amount": Any<Number>,
       "currency": "AUD",
     },
     "fuel_surcharge_tax": {
-      "amount": 0,
+      "amount": Any<Number>,
       "currency": "AUD",
     },
   },
@@ -51,15 +51,15 @@ exports[`Products > should get a list of products 1`] = `
   },
   "quote": {
     "gross": {
-      "amount": 10.23,
+      "amount": Any<Number>,
       "currency": "AUD",
     },
     "net": {
-      "amount": 9.3,
+      "amount": Any<Number>,
       "currency": "AUD",
     },
     "tax": {
-      "amount": 0.93,
+      "amount": Any<Number>,
       "currency": "AUD",
     },
   },
@@ -69,7 +69,7 @@ exports[`Products > should get a list of products 1`] = `
   },
   "tax_breakdown": {
     "gst": {
-      "amount": 0.93,
+      "amount": Any<Number>,
       "currency": "AUD",
       "rate": 0.1,
     },

--- a/test/__snapshots__/quote.test.ts.snap
+++ b/test/__snapshots__/quote.test.ts.snap
@@ -12,14 +12,14 @@ exports[`Quote > should return a quote 1`] = `
     ],
     "for_pickup_date": Any<String>,
   },
-  "plan_name": "Easy",
+  "plan_name": Any<String>,
   "price_breakdown": {
     "base": {
-      "amount": 9.3,
+      "amount": Any<Number>,
       "currency": "AUD",
     },
     "base_tax": {
-      "amount": 0.93,
+      "amount": Any<Number>,
       "currency": "AUD",
     },
     "cover": {
@@ -39,25 +39,25 @@ exports[`Quote > should return a quote 1`] = `
       "currency": "AUD",
     },
     "fuel_surcharge": {
-      "amount": 0,
+      "amount": Any<Number>,
       "currency": "AUD",
     },
     "fuel_surcharge_tax": {
-      "amount": 0,
+      "amount": Any<Number>,
       "currency": "AUD",
     },
   },
   "quote": {
     "gross": {
-      "amount": 10.23,
+      "amount": Any<Number>,
       "currency": "AUD",
     },
     "net": {
-      "amount": 9.3,
+      "amount": Any<Number>,
       "currency": "AUD",
     },
     "tax": {
-      "amount": 0.93,
+      "amount": Any<Number>,
       "currency": "AUD",
     },
   },
@@ -67,7 +67,7 @@ exports[`Quote > should return a quote 1`] = `
   },
   "tax_breakdown": {
     "gst": {
-      "amount": 0.93,
+      "amount": Any<Number>,
       "currency": "AUD",
       "rate": 0.1,
     },

--- a/test/orders.test.ts
+++ b/test/orders.test.ts
@@ -59,6 +59,42 @@ describe('Orders', () => {
         estimated_delivery_date_minimum: expect.any(String),
         estimated_delivery_date_maximum: expect.any(String),
       },
+      sender: {
+        contact: {
+          email: expect.any(String),
+          sendle_id: expect.any(String),
+        },
+      },
+      price: {
+        gross: {
+          amount: expect.any(Number),
+        },
+        net: {
+          amount: expect.any(Number),
+        },
+        tax: {
+          amount: expect.any(Number),
+        },
+      },
+      price_breakdown: {
+        base: {
+          amount: expect.any(Number),
+        },
+        base_tax: {
+          amount: expect.any(Number),
+        },
+        fuel_surcharge: {
+          amount: expect.any(Number),
+        },
+        fuel_surcharge_tax: {
+          amount: expect.any(Number),
+        },
+      },
+      tax_breakdown: {
+        gst: {
+          amount: expect.any(Number),
+        },
+      },
     });
   });
 
@@ -109,6 +145,7 @@ describe('Orders', () => {
         description: 'T-shirt',
         value: '20.00',
         country_of_origin: 'China',
+        hs_code: '610910',
       },
     });
 
@@ -122,6 +159,23 @@ describe('Orders', () => {
         pickup_date: expect.any(String),
         estimated_delivery_date_minimum: expect.any(String),
         estimated_delivery_date_maximum: expect.any(String),
+      },
+      sender: {
+        contact: {
+          email: expect.any(String),
+          sendle_id: expect.any(String),
+        },
+      },
+      price: {
+        gross: {
+          amount: expect.any(Number),
+        },
+        net: {
+          amount: expect.any(Number),
+        },
+        tax: {
+          amount: expect.any(Number),
+        },
       },
     });
   });
@@ -155,6 +209,7 @@ describe('Orders', () => {
     expect(order).toMatchSnapshot({
       order_id: expect.any(String),
       cancelled_at: expect.any(String),
+      cancellation_message: expect.any(String),
       order_url: expect.any(String),
       sendle_reference: expect.any(String),
       tracking_url: expect.any(String),

--- a/test/orders.test.ts
+++ b/test/orders.test.ts
@@ -177,6 +177,20 @@ describe('Orders', () => {
           amount: expect.any(Number),
         },
       },
+      price_breakdown: {
+        base: {
+          amount: expect.any(Number),
+        },
+        base_tax: {
+          amount: expect.any(Number),
+        },
+        fuel_surcharge: {
+          amount: expect.any(Number),
+        },
+        fuel_surcharge_tax: {
+          amount: expect.any(Number),
+        },
+      },
     });
   });
 

--- a/test/products.test.ts
+++ b/test/products.test.ts
@@ -20,6 +20,36 @@ describe('Products', () => {
         days_range: expect.any(Array),
         for_send_date: expect.any(String)
       },
+      price_breakdown: {
+        base: {
+          amount: expect.any(Number),
+        },
+        base_tax: {
+          amount: expect.any(Number),
+        },
+        fuel_surcharge: {
+          amount: expect.any(Number),
+        },
+        fuel_surcharge_tax: {
+          amount: expect.any(Number),
+        },
+      },
+      tax_breakdown: {
+        gst: {
+          amount: expect.any(Number),
+        },
+      },
+      quote: {
+        gross: {
+          amount: expect.any(Number),
+        },
+        net: {
+          amount: expect.any(Number),
+        },
+        tax: {
+          amount: expect.any(Number),
+        },
+      },
     });
   });
 });

--- a/test/quote.test.ts
+++ b/test/quote.test.ts
@@ -18,6 +18,37 @@ describe('Quote', () => {
         days_range: expect.arrayContaining([expect.any(Number)]),
         for_pickup_date: expect.any(String),
       },
+      plan_name: expect.any(String),
+      price_breakdown: {
+        base: {
+          amount: expect.any(Number),
+        },
+        base_tax: {
+          amount: expect.any(Number),
+        },
+        fuel_surcharge: {
+          amount: expect.any(Number),
+        },
+        fuel_surcharge_tax: {
+          amount: expect.any(Number),
+        },
+      },
+      tax_breakdown: {
+        gst: {
+          amount: expect.any(Number),
+        },
+      },
+      quote: {
+        gross: {
+          amount: expect.any(Number),
+        },
+        net: {
+          amount: expect.any(Number),
+        },
+        tax: {
+          amount: expect.any(Number),
+        },
+      },
     });
   });
 });


### PR DESCRIPTION
Hi there! I'm in charge of API docs for Sendle – love this repo and this library!

Since https://developers.sendle.com/changelog/requiring-hs-codes-for-au-international Sendle now requires HS codes when creating international shipments, have updated the international test and the types to reflect this.

I've also changed the tests a little, ensuring they continue working with price fluctuations and when different Sendle IDs are used. I'm not sure whether you'd prefer this approach to handling the prices or you'd prefer to manually update the test files now and then as in e90451d0c4c26eb0131aff6c4641fde9600936ef. Some aspects like the fuel surcharge can change month-to-month, so having at least those and the total price/tax be dynamic might make sense.